### PR TITLE
Update VK_EXT_image_compression_control support query example

### DIFF
--- a/proposals/VK_EXT_image_compression_control.adoc
+++ b/proposals/VK_EXT_image_compression_control.adoc
@@ -223,14 +223,9 @@ To query what rates the implementation supports:
 
 [source,c]
 ----
-
-VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceImageFormatProperties2(
-    VkPhysicalDevice                            physicalDevice,
-    const VkPhysicalDeviceImageFormatInfo2*     pImageFormatInfo,
-    VkImageFormatProperties2*                   pImageFormatProperties);
-
 VkPhysicalDeviceImageFormatInfo2 imageFormatInfo = {};
-// fill in imageFormatInfo as usual
+// fill in imageFormatInfo as usual, but also add:
+imageFormatInfo.pNext  = &compressionControl;
 
 VkImageFormatProperties2 imageFormatProperties = {};
 VkImageCompressionPropertiesEXT compressionProperties = {};


### PR DESCRIPTION
According to the [Spec](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImageCompressionPropertiesEXT.html), `VkImageCompressionPropertiesEXT` will be empty unless a `VkImageCompressionControlEXT` is added to the `VkPhysicalDeviceImageFormatInfo2` `pNext` chain. This might be easy to miss if following the example as it was laid out before. 

Additionally, removed the signature of `vkGetPhysicalDeviceImageFormatProperties2` as it was not necessary.